### PR TITLE
point to cdn location of babylon.js

### DIFF
--- a/src/zipContent/index.html
+++ b/src/zipContent/index.html
@@ -5,8 +5,8 @@
 
     <title>Babylon.js sample code</title>
     <!-- Babylon.js -->
-    <script src="http://www.babylonjs.com/hand.minified-1.2.js"></script>
-    <script src="http://www.babylonjs.com/babylon.js"></script>
+    <script src="https://code.jquery.com/pep/0.4.3/pep.js"></script>
+    <script src="https://cdn.babylonjs.com/babylon.js"></script>
     <style>
         html, body {
             overflow: hidden;


### PR DESCRIPTION
point to the cdn location of babylon.js and replaced hand.js by pep.js